### PR TITLE
Urlencode flag

### DIFF
--- a/src/http_overeasy/http_client.py
+++ b/src/http_overeasy/http_client.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any
 from typing import Dict
 from typing import Optional
+from urllib import parse
 
 import urllib3
 from http_overeasy.response import Response
@@ -85,6 +86,7 @@ class HTTPClient:
         url: str,
         body: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, str]] = None,
+        urlencode: bool = False,
     ) -> Response:
         """
         POST method with Response model returned
@@ -93,17 +95,19 @@ class HTTPClient:
             url: HTTPS URL of target
             body: {key:value} dict of payload to be delivered
             headers: Optional headers to use over global headers
+            urlencode: When true, body is sent as urlencoded string
 
         Returns:
             Response
         """
-        return self._request_with_body("POST", url, body, headers)
+        return self._request_with_body("POST", url, body, headers, urlencode)
 
     def put(
         self,
         url: str,
         body: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, str]] = None,
+        urlencode: bool = False,
     ) -> Response:
         """
         PUT method with Response model returned
@@ -112,17 +116,19 @@ class HTTPClient:
             url: HTTPS URL of target
             body: {key:value} dict of payload to be delivered
             headers: Optional headers to use over global headers
+            urlencode: When true, body is sent as urlencoded string
 
         Returns:
             Response
         """
-        return self._request_with_body("PUT", url, body, headers)
+        return self._request_with_body("PUT", url, body, headers, urlencode)
 
     def patch(
         self,
         url: str,
         body: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, str]] = None,
+        urlencode: bool = False,
     ) -> Response:
         """
         PATCH method with Response model returned
@@ -131,11 +137,12 @@ class HTTPClient:
             url: HTTPS URL of target
             body: {key:value} dict of payload to be delivered
             headers: Optional headers to use over global headers
+            urlencode: When true, body is sent as urlencoded string
 
         Returns:
             Response
         """
-        return self._request_with_body("PATCH", url, body, headers)
+        return self._request_with_body("PATCH", url, body, headers, urlencode)
 
     def _request_with_body(
         self,
@@ -143,15 +150,21 @@ class HTTPClient:
         url: str,
         body: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, str]] = None,
+        urlencode: bool = False,
     ) -> Response:
         """Internal: Handles POST, PUT, and PATCH"""
         headers = headers if headers is not None else self.headers
+
+        if urlencode:
+            request_body = parse.urlencode(body or {}, doseq=True)
+        else:
+            request_body = json.dumps(body)
 
         resp = Response(
             self.http.request(
                 method=method.upper(),
                 url=url,
-                body=json.dumps(body),
+                body=request_body,
                 headers=headers,
             )
         )

--- a/tests/http_client_test.py
+++ b/tests/http_client_test.py
@@ -3,6 +3,7 @@ from typing import Any
 from typing import Dict
 from typing import Generator
 from typing import Optional
+from typing import Tuple
 from unittest.mock import MagicMock
 from unittest.mock import patch
 from urllib import parse
@@ -46,6 +47,24 @@ def patch_client() -> Generator[HTTPClient, None, None]:
         client.http.clear()
 
 
+@pytest.fixture(params=(["post", "patch", "put"]))
+def send_fixtures(
+    patch_client: HTTPClient,
+    request: Any,
+) -> Generator[Tuple[HTTPClient, str], None, None]:
+    """Methods that send data to an API: POST, PATCH, PUT"""
+    yield patch_client, request.param
+
+
+@pytest.fixture(params=(["get", "delete"]))
+def fetch_fixtures(
+    patch_client: HTTPClient,
+    request: Any,
+) -> Generator[Tuple[HTTPClient, str], None, None]:
+    """Methods that fetch data from an API: GET, DELETE"""
+    yield patch_client, request.param
+
+
 def test_custom_connection_pool_count(test_client: HTTPClient) -> None:
     assert test_client.http.pools._maxsize == MAX_POOLS
 
@@ -77,44 +96,23 @@ def test_default_constants(base_client: HTTPClient) -> None:
         ("", None, None),
     ),
 )
-def test_get_with_parameters(
+def test_fetch_methods(
     url: str,
     fields: Optional[Dict[str, Any]],
     headers: Optional[Dict[str, str]],
-    patch_client: HTTPClient,
+    fetch_fixtures: Tuple[HTTPClient, str],
 ) -> None:
-    result = patch_client.get(url, fields, headers)
+    patch_client, send_method = fetch_fixtures
+    result = getattr(patch_client, send_method)(url, fields, headers)
+
     assert isinstance(result, Response)
+
+    patch_client.http.request.assert_called_once()
     patch_client.http.request.assert_called_with(
         url=url,
         fields=fields,
         headers=headers,
-        method="GET",
-    )
-
-
-@pytest.mark.parametrize(
-    argnames=("url", "fields", "headers"),
-    argvalues=(
-        ("https://google.com", {"test": "test01"}, MOCK_HEADERS),
-        ("https://google.com", None, MOCK_HEADERS),
-        ("https://google.com", {"test": "test01"}, None),
-        ("", None, None),
-    ),
-)
-def test_delete_with_parameters(
-    url: str,
-    fields: Optional[Dict[str, Any]],
-    headers: Optional[Dict[str, str]],
-    patch_client: HTTPClient,
-) -> None:
-    result = patch_client.delete(url, fields, headers)
-    assert isinstance(result, Response)
-    patch_client.http.request.assert_called_with(
-        url=url,
-        fields=fields,
-        headers=headers,
-        method="DELETE",
+        method=send_method.upper(),
     )
 
 
@@ -131,75 +129,28 @@ def test_delete_with_parameters(
         ("", None, None, True),
     ),
 )
-def test_post_with_parameters(
+def test_send_methods(
     url: str,
     body: Optional[Dict[str, Any]],
     headers: Optional[Dict[str, str]],
-    patch_client: HTTPClient,
     urlencode: bool,
+    send_fixtures: Tuple[HTTPClient, str],
 ) -> None:
-    result = patch_client.post(url, body, headers, urlencode)
+    patch_client, send_method = send_fixtures
+    result = getattr(patch_client, send_method)(url, body, headers, urlencode)
+
     assert isinstance(result, Response)
     if urlencode:
         expected_body = parse.urlencode(body or {}, doseq=True)
     else:
         expected_body = json.dumps(body)
 
+    patch_client.http.request.assert_called_once()
     patch_client.http.request.assert_called_with(
         url=url,
         body=expected_body,
         headers=headers,
-        method="POST",
-    )
-
-
-@pytest.mark.parametrize(
-    argnames=("url", "body", "headers"),
-    argvalues=(
-        ("https://google.com", {"test": "test01"}, MOCK_HEADERS),
-        ("https://google.com", None, MOCK_HEADERS),
-        ("https://google.com", {"test": "test01"}, None),
-        ("", None, None),
-    ),
-)
-def test_put_with_parameters(
-    url: str,
-    body: Optional[Dict[str, Any]],
-    headers: Optional[Dict[str, str]],
-    patch_client: HTTPClient,
-) -> None:
-    result = patch_client.put(url, body, headers)
-    assert isinstance(result, Response)
-    patch_client.http.request.assert_called_with(
-        url=url,
-        body=json.dumps(body),
-        headers=headers,
-        method="PUT",
-    )
-
-
-@pytest.mark.parametrize(
-    argnames=("url", "body", "headers"),
-    argvalues=(
-        ("https://google.com", {"test": "test01"}, MOCK_HEADERS),
-        ("https://google.com", None, MOCK_HEADERS),
-        ("https://google.com", {"test": "test01"}, None),
-        ("", None, None),
-    ),
-)
-def test_patch_with_parameters(
-    url: str,
-    body: Optional[Dict[str, Any]],
-    headers: Optional[Dict[str, str]],
-    patch_client: HTTPClient,
-) -> None:
-    result = patch_client.patch(url, body, headers)
-    assert isinstance(result, Response)
-    patch_client.http.request.assert_called_with(
-        url=url,
-        body=json.dumps(body),
-        headers=headers,
-        method="PATCH",
+        method=send_method.upper(),
     )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310
+envlist = py38,py39,py310,pre-commit
 skip_missing_interpreters = true
 
 [testenv]
@@ -10,3 +10,8 @@ commands =
     coverage run -m pytest {posargs:tests}
     coverage xml
     coverage report --fail-under 95 --skip-covered --skip-empty -m
+
+[testenv:pre-commit]
+skip_install = true
+deps = pre-commit
+commands = pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
- Add support for sending `POST`, `PUT`, and `PATCH` bodies as urlencoded strings.
- Refactor and clean tests