### PR TITLE
[breaking] Determine encoding based on headers

### DIFF
--- a/src/http_overeasy/http_client.py
+++ b/src/http_overeasy/http_client.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
+
 import json
 import logging
 from typing import Any
-from typing import Dict
-from typing import Optional
 from urllib import parse
 
 import urllib3
@@ -22,7 +22,7 @@ class HTTPClient:
     def __init__(
         self,
         *,
-        headers: Optional[Dict[str, str]] = None,
+        headers: dict[str, str] | None = None,
         max_pool: int = 10,
     ) -> None:
         self.log = logging.getLogger(__name__)
@@ -46,8 +46,8 @@ class HTTPClient:
     def get(
         self,
         url: str,
-        fields: Optional[Dict[str, Any]] = None,
-        headers: Optional[Dict[str, str]] = None,
+        fields: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> Response:
         """
         GET method with Response model returned
@@ -65,8 +65,8 @@ class HTTPClient:
     def delete(
         self,
         url: str,
-        fields: Optional[Dict[str, Any]] = None,
-        headers: Optional[Dict[str, str]] = None,
+        fields: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> Response:
         """
         DELETE method with Response model returned
@@ -84,8 +84,8 @@ class HTTPClient:
     def post(
         self,
         url: str,
-        body: Optional[Dict[str, Any]] = None,
-        headers: Optional[Dict[str, str]] = None,
+        body: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> Response:
         """
         POST method with Response model returned
@@ -104,8 +104,8 @@ class HTTPClient:
     def put(
         self,
         url: str,
-        body: Optional[Dict[str, Any]] = None,
-        headers: Optional[Dict[str, str]] = None,
+        body: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> Response:
         """
         PUT method with Response model returned
@@ -124,8 +124,8 @@ class HTTPClient:
     def patch(
         self,
         url: str,
-        body: Optional[Dict[str, Any]] = None,
-        headers: Optional[Dict[str, str]] = None,
+        body: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> Response:
         """
         PATCH method with Response model returned
@@ -145,8 +145,8 @@ class HTTPClient:
         self,
         method: str,
         url: str,
-        body: Optional[Dict[str, Any]] = None,
-        headers: Optional[Dict[str, str]] = None,
+        body: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> Response:
         """Internal: Handles POST, PUT, and PATCH"""
         headers = self._format_headers(headers) if headers is not None else self.headers
@@ -170,8 +170,8 @@ class HTTPClient:
         self,
         method: str,
         url: str,
-        fields: Optional[Dict[str, Any]] = None,
-        headers: Optional[Dict[str, str]] = None,
+        fields: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> Response:
         """Internal: Handles GET and DELETE"""
         headers = self._format_headers(headers) if headers is not None else self.headers
@@ -187,13 +187,13 @@ class HTTPClient:
         return resp
 
     @staticmethod
-    def _is_urlencoded(headers: Optional[Dict[str, str]]) -> bool:
+    def _is_urlencoded(headers: dict[str, str] | None) -> bool:
         """Determine how to encode the body"""
         if headers is not None:
             return not headers.get("content-type", "") == "application/json"
         return False
 
     @staticmethod
-    def _format_headers(headers: Dict[str, str]) -> Dict[str, str]:
+    def _format_headers(headers: dict[str, str]) -> dict[str, str]:
         """Adjust all keys to lower-case"""
         return {key.lower(): value for key, value in headers.items()}

--- a/src/http_overeasy/response.py
+++ b/src/http_overeasy/response.py
@@ -1,7 +1,7 @@
+from __future__ import annotations
+
 import json
 from typing import Any
-from typing import Dict
-from typing import Optional
 
 from urllib3.response import HTTPResponse
 
@@ -15,11 +15,11 @@ class Response:
         """determines if status code returned is 200-299"""
         return self.http_response.status in range(200, 300)
 
-    def get_headers(self) -> Dict[str, Any]:
+    def get_headers(self) -> dict[str, Any]:
         """response headers"""
         return dict(self.http_response.headers)
 
-    def get_body(self) -> Optional[str]:
+    def get_body(self) -> str | None:
         """utf-8 decoded response body"""
         return self._body.decode("utf-8") if self._body is not None else None
 
@@ -27,7 +27,7 @@ class Response:
         """status code of response"""
         return self.http_response.status
 
-    def get_json(self) -> Optional[Dict[str, Any]]:
+    def get_json(self) -> dict[str, Any] | None:
         """json body as a dict if response body is valid json, else None"""
         try:
             return json.loads(self.get_body() or "")


### PR DESCRIPTION
Because we should.

Breaking: This change removes the `urlencoded` parameter from `HTTPClient` method calls. The function of this parameter is now controlled by the header `content-type` which will either be serialized (`application/json`) or will be urlencoded.

closes #5 