### PR TITLE
[Breaking] Preocts 20220607

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ RETRY_ALLOWED_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"]
     - Args:
       - `url` : `str`
         - HTTPS URL of target
+    - Keyword Args:
       - `fields` : `dict[str, Any] | None` (default: `None`)
         - {key:value} dict of fields to be translated to urlecoded string
       - `headers` `dict[str, str] | None` (default: `None`)
@@ -76,6 +77,7 @@ RETRY_ALLOWED_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"]
     - Args:
       - `url` : `str`
         - HTTPS URL of target
+    - Keyword Args:
       - `fields` : `dict[str, Any] | None` (default: `None`)
         - {key:value} dict of fields to be translated to urlecoded string
       - `headers` `dict[str, str] | None` (default: `None`)
@@ -84,33 +86,45 @@ RETRY_ALLOWED_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"]
       - `Response`
   - `post(...)`
     - POST method with Response model returned
+    - NOTE: Only json or fields can be provided, not both.
     - Args:
       - `url` : `str`
         - HTTPS URL of target
-      - `body` : `dict[str, Any] | None` (default: `None`)
+    - Keyword Args:
+      - `json` : `dict[str, Any] | None` (default: `None`)
         - {key:value} dict of payload to be delivered
+      - `fields` : `dict[str, Any] | None` (default: `None`)
+        - {key:value} dict of fields to be translated to urlecoded string
       - `headers` `dict[str, str] | None` (default: `None`)
         - Optional headers to use over global headers
     - Returns:
       - `Response`
   - `put(...)`
     - PUT method with Response model returned
+    - NOTE: Only json or fields can be provided, not both.
     - Args:
       - `url` : `str`
         - HTTPS URL of target
-      - `body` : `dict[str, Any] | None` (default: `None`)
+    - Keyword Args:
+      - `json` : `dict[str, Any] | None` (default: `None`)
         - {key:value} dict of payload to be delivered
+      - `fields` : `dict[str, Any] | None` (default: `None`)
+        - {key:value} dict of fields to be translated to urlecoded string
       - `headers` `dict[str, str] | None` (default: `None`)
         - Optional headers to use over global headers
     - Returns:
       - `Response`
   - `patch(...)`
     - PATCH method with Response model returned
+    - NOTE: Only json or fields can be provided, not both.
     - Args:
       - `url` : `str`
         - HTTPS URL of target
-      - `body` : `dict[str, Any] | None` (default: `None`)
+    - Keyword Args:
+      - `json` : `dict[str, Any] | None` (default: `None`)
         - {key:value} dict of payload to be delivered
+      - `fields` : `dict[str, Any] | None` (default: `None`)
+        - {key:value} dict of fields to be translated to urlecoded string
       - `headers` `dict[str, str] | None` (default: `None`)
         - Optional headers to use over global headers
     - Returns:
@@ -126,17 +140,21 @@ All `HTTPResponses` are wrapped in a custom model that provides quick access to 
 - `http_response` : `urllib3.response.HTTPResponse`
   - The original `HTTPResponse` object as returned by `urllib3`
 
+**Properties**
+
+- `status_code` : `int`
+  - Status code of response
+- `text` : `str`
+  - UTF-8 decoded response body
+- `headers: `dict[str, Any]`
+  - Response headers
+
 **Methods**
 
 - `has_success` : `bool`
   - Boolean mark of a response code of 200 to 299
-- `get_body` : `str | None`
-  - UTF-8 decoded response body
-- `get_status` : `int`
-  - Status code of response
-- `get_json` : `dict[str, Any] | None`
+- `json` : `dict[str, Any] | None`
   - JSON decoded dict of response body
-  - Note: will be `None` if response is not valid JSON
 
 
 ## `ClientMocker` Object
@@ -192,8 +210,8 @@ the desired version while creating the `venv`. (e.g. `python3` or `python3.8`)
 Clone this repo and enter root directory of repo:
 
 ```bash
-git clone https://github.com/{{ORG_NAME}}/{{REPO_NAME}}
-cd {{REPO_NAME}}
+git clone https://github.com/Preocts/http_overeasy
+cd http_overeasy
 ```
 
 Create the `venv`:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = http_overeasy
-version = 1.3.2
+version = 1.4.0
 description = Wrapper around urllib3
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/http_overeasy/http_client.py
+++ b/src/http_overeasy/http_client.py
@@ -46,6 +46,7 @@ class HTTPClient:
     def get(
         self,
         url: str,
+        *,
         fields: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
     ) -> Response:
@@ -65,6 +66,7 @@ class HTTPClient:
     def delete(
         self,
         url: str,
+        *,
         fields: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
     ) -> Response:

--- a/src/http_overeasy/response.py
+++ b/src/http_overeasy/response.py
@@ -14,7 +14,7 @@ class Response:
         self._body = self.http_response.data
 
     @property
-    def status(self) -> int:
+    def status_code(self) -> int:
         """Status code of response."""
         return self.http_response.status
 

--- a/src/http_overeasy/response.py
+++ b/src/http_overeasy/response.py
@@ -1,3 +1,4 @@
+"""Model response object."""
 from __future__ import annotations
 
 import json
@@ -8,28 +9,29 @@ from urllib3.response import HTTPResponse
 
 class Response:
     def __init__(self, http_response: HTTPResponse) -> None:
+        """Initialize response object."""
         self.http_response = http_response
         self._body = self.http_response.data
 
-    def has_success(self) -> bool:
-        """determines if status code returned is 200-299"""
-        return self.http_response.status in range(200, 300)
-
-    def get_headers(self) -> dict[str, Any]:
-        """response headers"""
-        return dict(self.http_response.headers)
-
-    def get_body(self) -> str | None:
-        """utf-8 decoded response body"""
-        return self._body.decode("utf-8") if self._body is not None else None
-
-    def get_status(self) -> int:
-        """status code of response"""
+    @property
+    def status(self) -> int:
+        """Status code of response."""
         return self.http_response.status
 
-    def get_json(self) -> dict[str, Any] | None:
-        """json body as a dict if response body is valid json, else None"""
-        try:
-            return json.loads(self.get_body() or "")
-        except json.JSONDecodeError:
-            return None
+    @property
+    def text(self) -> str:
+        """UTF-8 decoded response body."""
+        return self._body.decode("utf-8") if self._body else ""
+
+    @property
+    def headers(self) -> dict[str, Any]:
+        """Response headers."""
+        return dict(self.http_response.headers)
+
+    def has_success(self) -> bool:
+        """Determine if status code returned is 200-299."""
+        return self.http_response.status in range(200, 300)
+
+    def json(self) -> dict[str, Any] | None:
+        """JSON body as a dict if response body is valid json, else None."""
+        return json.loads(self.text)

--- a/tests/client_mocker_test.py
+++ b/tests/client_mocker_test.py
@@ -38,7 +38,7 @@ def test_add_response_dict_all_calls(method: str) -> None:
     result = getattr(client, method)(url=MOCK_URL)
 
     assert result.text == json.dumps(MOCK_RESP)
-    assert result.status == MOCK_STATUS
+    assert result.status_code == MOCK_STATUS
     assert result.headers == MOCK_HEADER
 
 

--- a/tests/client_mocker_test.py
+++ b/tests/client_mocker_test.py
@@ -37,9 +37,9 @@ def test_add_response_dict_all_calls(method: str) -> None:
 
     result = getattr(client, method)(url=MOCK_URL)
 
-    assert result.get_body() == json.dumps(MOCK_RESP)
-    assert result.get_status() == MOCK_STATUS
-    assert result.get_headers() == MOCK_HEADER
+    assert result.text == json.dumps(MOCK_RESP)
+    assert result.status == MOCK_STATUS
+    assert result.headers == MOCK_HEADER
 
 
 def test_add_response_list() -> None:
@@ -49,7 +49,7 @@ def test_add_response_list() -> None:
 
     result = client.get(MOCK_URL)
 
-    assert result.get_json() == resp
+    assert result.json() == resp
 
 
 def test_add_response_str() -> None:
@@ -59,7 +59,7 @@ def test_add_response_str() -> None:
 
     result = client.get(MOCK_URL)
 
-    assert result.get_body() == resp
+    assert result.text == resp
 
 
 def test_add_response_byte() -> None:
@@ -69,7 +69,7 @@ def test_add_response_byte() -> None:
 
     result = client.get(url=MOCK_URL)
 
-    assert result.get_body() == resp.decode()
+    assert result.text == resp.decode()
 
 
 def test_url_mismatch_positional() -> None:
@@ -86,4 +86,4 @@ def test_url_match_partial() -> None:
 
     result = client.get(MOCK_URL[:10])
 
-    assert result.get_headers() == MOCK_HEADER
+    assert result.headers == MOCK_HEADER

--- a/tests/http_client_test.py
+++ b/tests/http_client_test.py
@@ -107,7 +107,7 @@ def test_fetch_methods(
     fetch_fixtures: Tuple[HTTPClient, str],
 ) -> None:
     patch_client, send_method = fetch_fixtures
-    result = getattr(patch_client, send_method)(url, fields, headers)
+    result = getattr(patch_client, send_method)(url, fields=fields, headers=headers)
 
     assert isinstance(result, Response)
 

--- a/tests/response_test.py
+++ b/tests/response_test.py
@@ -66,7 +66,7 @@ def test_body_capture(response_obj: ResponseObj) -> None:
 
 
 def test_get_status_code(response_obj: ResponseObj) -> None:
-    assert response_obj.resp.status == response_obj.status
+    assert response_obj.resp.status_code == response_obj.status
 
 
 def test_get_json(response_obj: ResponseObj) -> None:


### PR DESCRIPTION
Breaking changes:

- Change the method and property structure of Response object to match how `requests` and `httpx` work for betting mobility to a production framework
- Refactor `http_client.py` to use a single request handler behind the abstract layer
  - `field`, `body`, and `header` are now keyword required parameters for POST, PUT, PATCH methods
  - `field`, and `header` are now keyword required parameters for GET, DELETE methods

